### PR TITLE
Update insert_editor_css usage to insert_global_admin_css

### DIFF
--- a/src/wagtail_analytics/wagtail_hooks.py
+++ b/src/wagtail_analytics/wagtail_hooks.py
@@ -67,8 +67,8 @@ def register_menu_item():
     )
 
 
-@hooks.register("insert_editor_css")
-def insert_analytics_css():
+@hooks.register("insert_global_admin_css")
+def insert_global_admin_css():
     css_files = ["chart.js/Chart.min.css", "wagtailanalytics/main.css"]
     css_includes = format_html_join(
         "\n",


### PR DESCRIPTION
Wagtail's `insert_editor_css` hook was deprecated in Wagtail 5.1: https://docs.wagtail.org/en/stable/releases/5.1.html#maintenance