### PR TITLE
Fix Wagtail RemovedInWagtail60 deprecation warning

### DIFF
--- a/src/wagtail_analytics/wagtail_hooks.py
+++ b/src/wagtail_analytics/wagtail_hooks.py
@@ -52,7 +52,7 @@ def register_menu():
     return SubmenuMenuItem(
         wagtail_analytics_settings.MENU_LABEL,
         wagtail_analytics_menu,
-        classnames="icon icon-view",
+        classname="icon icon-view",
         order=wagtail_analytics_settings.MENU_ORDER,
     )
 
@@ -62,7 +62,7 @@ def register_menu_item():
     return WagtailAnalyticsMenuItem(
         _("Dashboard"),
         reverse("wagtail-analytics-dashboard"),
-        classnames="icon icon-view",
+        classname="icon icon-view",
         order=0,
     )
 


### PR DESCRIPTION
> RemovedInWagtail60Warning: The `classnames` kwarg for MenuItem is
> deprecated - use `classname` instead

Ref: https://docs.wagtail.org/en/stable/releases/5.2.html#adoption-of-classname-convention-for-menuitem-related-classes-and-hooks